### PR TITLE
호텔 재귀오류 방지 위해 OneToMany fetch lazy추가

### DIFF
--- a/src/main/java/com/ntt/ntt/Controller/ServiceCategory/ServiceCateController.java
+++ b/src/main/java/com/ntt/ntt/Controller/ServiceCategory/ServiceCateController.java
@@ -36,12 +36,13 @@ public class ServiceCateController {
 
     @Operation(summary = "등록폼", description = "등록폼 페이지로 이동한다.")
     @GetMapping("/register")
-    public String registerForm(Model model){
+    public String registerForm(@RequestParam(required = false) Integer hotelId, Model model){
         //검증처리가 필요하면 빈 CateDTO를 생성해서 전달한다.
         model.addAttribute("serviceCateDTO", new ServiceCateDTO());
 
         //hotelDTO hotelName 전달하기
         List<HotelDTO> hotelDTOS = serviceCateService.getAllHotel();
+        model.addAttribute("selectedHotelId", hotelId);
         model.addAttribute("hotelDTOS", hotelDTOS);
         model.addAttribute("hotelDTO", new HotelDTO());
 

--- a/src/main/java/com/ntt/ntt/Controller/ServiceMenu/ServiceMenuController.java
+++ b/src/main/java/com/ntt/ntt/Controller/ServiceMenu/ServiceMenuController.java
@@ -36,11 +36,12 @@ public class ServiceMenuController {
 
     @Operation(summary = "등록폼", description = "등록폼 페이지로 이동한다.")
     @GetMapping("/register")
-    public String registerForm(Model model){
+    public String registerForm(@RequestParam(required = false) Integer serviceCateId, Model model){
         //검증처리가 필요하면 빈 MenuDTO를 생성해서 전달한다.
         List<ServiceCateDTO> serviceCateDTOS = serviceCateService.getAllServiceCate();
         model.addAttribute("serviceCateDTOS", serviceCateDTOS);
         model.addAttribute("serviceMenuDTO", new ServiceMenuDTO());
+        model.addAttribute("selectServiceCateId", serviceCateId);
         return "/manager/roomservice/menu/register";
     }
 

--- a/src/main/java/com/ntt/ntt/Entity/Hotel.java
+++ b/src/main/java/com/ntt/ntt/Entity/Hotel.java
@@ -52,7 +52,8 @@ public class Hotel extends BaseEntity {
             orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Image> hotelImageList;
 
-    @OneToMany(mappedBy = "hotel", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "hotel", cascade = CascadeType.REMOVE,
+            orphanRemoval = true, fetch = FetchType.LAZY)
     private Set<LikeHotel> likeHotels;
 
     public Hotel(Integer hotelId) {
@@ -66,12 +67,12 @@ public class Hotel extends BaseEntity {
     private Company company;
 
     //2024-02-10 양방향 삭제를 위해 추가
-    @OneToMany(mappedBy = "hotelId", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "hotelId", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @ToString.Exclude //무한루프방지
     private List<Room> rooms;
 
     //2024-02-11 양방향 삭제를 위해 추가
-    @OneToMany(mappedBy = "hotel", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "hotel", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @ToString.Exclude //무한루프방지
     private List<ServiceCate> serviceCate;
 

--- a/src/main/java/com/ntt/ntt/Entity/ServiceCate.java
+++ b/src/main/java/com/ntt/ntt/Entity/ServiceCate.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Table(name="serviceCate")
 @Getter
 @Setter
-@ToString
+@ToString(exclude = "hotel")
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder

--- a/src/main/java/com/ntt/ntt/Service/company/CompanyService.java
+++ b/src/main/java/com/ntt/ntt/Service/company/CompanyService.java
@@ -90,7 +90,7 @@ public class CompanyService {
         int pageSize = 10;
         Pageable pageable = PageRequest.of(
                 currentPage, pageSize,
-                Sort.by(Sort.Direction.DESC, "companyId")
+                Sort.by(Sort.Direction.ASC, "companyId")
         );
 
         // 2. 검색타입에 따른 회사 조회

--- a/src/main/java/com/ntt/ntt/Service/hotel/HotelService.java
+++ b/src/main/java/com/ntt/ntt/Service/hotel/HotelService.java
@@ -98,7 +98,7 @@ public class HotelService {
         int pageSize = page.getPageSize(); // 페이지 사이즈 그대로 사용
         Pageable pageable = PageRequest.of(
                 currentPage, pageSize,
-                Sort.by(Sort.Direction.DESC, "hotelId") // 최신순으로 정렬
+                Sort.by(Sort.Direction.ASC, "hotelId") // 최신순으로 정렬
         );
 
         // 2. 검색타입에 따른 호텔 조회
@@ -218,7 +218,7 @@ public class HotelService {
     public Page<HotelDTO> list(Pageable page, String keyword, String searchType, boolean exactMatch) {
         int currentPage = page.getPageNumber();
         int pageSize = 9;
-        Pageable pageable = PageRequest.of(currentPage, pageSize, Sort.by(Sort.Direction.DESC, "hotelId"));
+        Pageable pageable = PageRequest.of(currentPage, pageSize, Sort.by(Sort.Direction.ASC, "hotelId"));
 
         Page<Hotel> hotels = null;
 

--- a/src/main/resources/templates/manager/roomservice/category/list.html
+++ b/src/main/resources/templates/manager/roomservice/category/list.html
@@ -34,6 +34,10 @@
             $(".modalBtn").click(function () {
                 var myModal = new bootstrap.Modal(document.getElementById('myModal'));
                 myModal.show();
+
+                // 현재 페이지 hotelId를 모달 select에 반영
+                const currentHotelId = [[${hotelId}]];
+                $("#modalHotelId").val(currentHotelId);
             });
 
             // 이미지 미리보기 기능
@@ -168,8 +172,9 @@
 
                 </div> <!-- row 끝 -->
                 <!-- 추가 버튼 -->
+                <!--등록 버튼 누를 때 해당하는 hotelId를 받을 수 있게 url 변경 2025-02-20-->
                 <div class="text-end mt-3">
-                    <button class="btn btn-primary" style="background-color: black" onclick="location.href='/roomService/category/register' ">등록</button>
+                    <a th:href="@{/roomService/category/register(hotelId=${hotelId})}" class="btn btn-primary">등록</a>
                     <button type="button" class="btn btn-primary modalBtn">간편 등록</button>
                 </div>
                 <!-- 페이지네이션 -->
@@ -221,10 +226,13 @@
                     <div class="modal-body">
                         <!--지사명을 통해 지사ID 가져오기 2025-02-11 추가-->
                         <div class="mb-3 mt-3">
-                            <label for="hotelId" class="form-label">지사명:</label>
-                            <select id="hotelId" name="hotelId" class="form-select">
+                            <label for="modalHotelId" class="form-label">지사명:</label>
+                            <select id="modalHotelId" name="hotelId" class="form-select">
                                 <th:block th:each="hotelDTOS : ${hotelDTOS}">
-                                    <option th:value="${hotelDTOS.hotelId}" th:text="${hotelDTOS.hotelName}">뒤에바</option>
+                                    <option th:value="${hotelDTOS.hotelId}"
+                                            th:text="${hotelDTOS.hotelName}"
+                                            th:selected="${hotelDTOS.hotelId == hotelId}">
+                                    </option>
                                 </th:block>
                             </select>
                         </div>

--- a/src/main/resources/templates/manager/roomservice/category/register.html
+++ b/src/main/resources/templates/manager/roomservice/category/register.html
@@ -17,11 +17,8 @@
             color: gray; /* 마우스 올리면 회색 */
         }
     </style>
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <link rel="stylesheet" th:href="@{/css/style.css}">
-
     <script th:inline="javascript">
-
+        src="https://code.jquery.com/jquery-3.6.0.min.js"
         // 이미지 미리보기 함수
         function previewImage(event) {
             console.log("수정 진입");
@@ -59,7 +56,17 @@
                 alert('이미지를 첨부해 주세요!');
             }
         }
+        function goToList() {
+            const selectedHotelId = document.getElementById('hotelId').value;
+            if (!selectedHotelId) {
+                alert('지사를 선택해 주세요.');
+                return;
+            }
+            window.location.href = `/roomService/category/list?hotelId=${selectedHotelId}`;
+        }
     </script>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+
 
 </head>
 <body>
@@ -78,11 +85,16 @@
                         <!--지사명을 통해 지사ID 가져오기 2025-02-11 추가-->
                         <div class="mb-3 mt-3">
                             <label for="hotelId" class="form-label">지사명:</label>
-                            <select id="hotelId" name="hotelId" class="form-select">
-                                <th:block th:each="hotelDTOS : ${hotelDTOS}">
-                                    <option th:value="${hotelDTOS.hotelId}" th:text="${hotelDTOS.hotelName}">뒤에바</option>
-                                </th:block>
-                            </select>
+                            <th:block>
+                                <select id="hotelId" name="hotelId" class="form-select">
+                                    <th:block th:each="hotelDTOS : ${hotelDTOS}">
+                                        <option th:value="${hotelDTOS.hotelId}"
+                                                th:text="${hotelDTOS.hotelName}"
+                                                th:selected="${hotelDTOS.hotelId == selectedHotelId}">
+                                        </option>
+                                    </th:block>
+                                </select>
+                            </th:block>
                         </div>
                         <div class="mb-3 mt-3">
                             <label for="serviceCateName" class="form-label">카테고리 명:</label>
@@ -107,7 +119,7 @@
 
                         <div style="text-align: right">
                             <button type="submit" class="btn btn-primary">등록</button>
-                            <button class="btn btn-primary" style="background-color: black" onclick="location.href='/roomService/category/list' ">목록</button>
+                            <button type="button" class="btn btn-primary" style="background-color: black" onclick="goToList()">목록</button>
                             <button type="reset" class="btn btn-secondary">초기화</button>
                         </div>
                     </form>
@@ -115,7 +127,7 @@
             </div>
         </div>
     </div>
-
 </div>
+
 </body>
 </html>

--- a/src/main/resources/templates/manager/roomservice/category/update.html
+++ b/src/main/resources/templates/manager/roomservice/category/update.html
@@ -92,7 +92,7 @@
 
                         <div style="text-align: right">
                             <button type="submit" class="btn btn-primary">수정</button>
-                            <a class="btn btn-primary" style="background-color: black" onclick="location.href='/roomService/category/list' ">목록</a>
+                            <a class="btn btn-primary" style="background-color: black" th:href="@{/roomService/category/list(hotelId=${serviceCateDTO.hotelId.hotelId})}">목록</a>
                             <button type="reset" class="btn btn-secondary">초기화</button>
                         </div>
                     </form>

--- a/src/main/resources/templates/manager/roomservice/menu/list.html
+++ b/src/main/resources/templates/manager/roomservice/menu/list.html
@@ -39,6 +39,10 @@
                 $('.modal-title').text("간편 등록하기");
                 $("#saveChanges").show();
                 modal.find("input").show();
+
+                //모달로 열었을 때 현재 보는 페이지의 serviceCateId인게 자동으로 카테고리 선택되게끔 하였음 2025-02-20
+                const currentServiceCateId = [[${serviceCateId}]];
+                $("#modalServiceCateId").val(currentServiceCateId);
             });
 
             // 이미지 미리보기
@@ -254,7 +258,7 @@
                 <!-- 추가 버튼 -->
                 <div class="text-end mt-3">
                     <a class="btn btn-primary" th:href="@{/roomService/category/list}">카테고리 관리</a>
-                    <button class="btn btn-primary" style="background-color: black" onclick="location.href='/roomService/menu/register'">등록</button>
+                    <a th:href="@{/roomService/menu/register(serviceCateId=${serviceCateId})}" class="btn btn-primary" style="background-color: black">등록</a>
                     <button type="button" class="btn btn-primary modalBtn">간편 등록</button>
                 </div>
 
@@ -303,11 +307,14 @@
                     <!-- Modal body -->
                     <div class="modal-body">
                         <div class="mb-3">
-                            <label for="serviceCateId" class="form-label">카테고리:</label>
-                            <select class="form-control" id="serviceCateId" name="serviceCateId" required>
+                            <label for="modalServiceCateId" class="form-label">카테고리:</label>
+                            <select class="form-control" id="modalServiceCateId" name="serviceCateId" required>
                                 <option value="" disabled selected>카테고리를 선택하세요</option>
                                 <th:block th:each="serviceCateDTOS : ${serviceCateDTOS}">
-                                    <option th:value="${serviceCateDTOS.serviceCateId}" th:text="${serviceCateDTOS.serviceCateName}"></option>
+                                    <option th:value="${serviceCateDTOS.serviceCateId}"
+                                            th:text="${serviceCateDTOS.serviceCateName}"
+                                            th:selected="${serviceCateDTOS.serviceCateId == serviceCateId}">
+                                    </option>
                                 </th:block>
                             </select>
                         </div>

--- a/src/main/resources/templates/manager/roomservice/menu/read.html
+++ b/src/main/resources/templates/manager/roomservice/menu/read.html
@@ -74,7 +74,7 @@
 
             <!-- 추가 버튼 -->
             <div class="text-end mt-3">
-                <button class="btn btn-primary" style="background-color: black" onclick="location.href='/roomService/menu/list' ">목록</button>
+                <a class="btn btn-primary" style="background-color: black" th:href="@{/roomService/menu/list(serviceCateId=${serviceMenuDTO.serviceCateId.serviceCateId})}">목록</a>
                 <a class="btn btn-primary" th:href="@{/roomService/menu/update(serviceMenuId=${serviceMenuDTO.serviceMenuId})}">수정</a>
                 <a class="btn btn-danger" th:href="@{/roomService/menu/delete(serviceMenuId=${serviceMenuDTO.serviceMenuId})}">삭제</a>
             </div>

--- a/src/main/resources/templates/manager/roomservice/menu/register.html
+++ b/src/main/resources/templates/manager/roomservice/menu/register.html
@@ -91,10 +91,11 @@
                     <div class="mb-3">
                         <label for="serviceCateId" class="form-label">카테고리:</label>
                         <select class="form-control" id="serviceCateId" name="serviceCateId" required>
-                            <option value="" disabled selected>카테고리를 선택하세요</option>
                             <!-- 카테고리 목록을 반복하여 선택 항목으로 표시 -->
                             <th:block th:each="serviceCateDTOS : ${serviceCateDTOS}">
-                                <option th:value="${serviceCateDTOS.serviceCateId}" th:text="${serviceCateDTOS.serviceCateName}"></option>
+                                <option th:value="${serviceCateDTOS.serviceCateId}"
+                                        th:text="${serviceCateDTOS.serviceCateName}"
+                                        th:selected="${serviceCateDTOS.serviceCateId == selectServiceCateId}"></option>
                             </th:block>
                         </select>
                     </div>
@@ -142,7 +143,7 @@
 
                     <div style="text-align: right">
                         <button type="submit" class="btn btn-primary mx-2">등록</button>
-                        <button class="btn btn-dark mx-2" onclick="location.href='/roomService/menu/list'">목록</button>
+                        <a class="btn btn-primary" style="background-color: black" th:href="@{/roomService/menu/list(serviceCateId=${serviceMenuDTO.serviceCateId})}">목록</a>
                         <button type="reset" class="btn btn-secondary mx-2">초기화</button>
                     </div>
 

--- a/src/main/resources/templates/manager/roomservice/menu/update.html
+++ b/src/main/resources/templates/manager/roomservice/menu/update.html
@@ -159,7 +159,7 @@
 
                             <div class="d-flex justify-content-center">
                                 <button type="submit" class="btn btn-primary">수정</button>  &nbsp&nbsp&nbsp
-                                <a class="btn btn-dark mx-2" onclick="location.href='/roomService/menu/list'">목록</a>
+                                <a class="btn btn-primary" style="background-color: black" th:href="@{/roomService/menu/list(serviceCateId=${serviceMenuDTO.serviceCateId.serviceCateId})}">목록</a>
                                 &nbsp&nbsp&nbsp
                                 <button type="reset" class="btn btn-secondary">초기화</button>
                             </div>


### PR DESCRIPTION
본사 지사 관리자 목록페이지 정렬순서 ASC로 변경
카테고리 관리자 페이지 등록->목록, 읽기->목록, 수정->목록 이동 시
부모의 ID 기준 정렬로 되게끔
메뉴 상동

카테고리, 메뉴 등록시 현재 보고 있는 페이지의 ID 따라가도록
select 수정, 모달등록도 같은 로직으로 수정
2025-02-20 오후